### PR TITLE
Top score fix.

### DIFF
--- a/Chaff.h
+++ b/Chaff.h
@@ -74,8 +74,13 @@ namespace Chaff
     void sow(const T& thing, const S& score) {
       if(mCompare(score, mTopScore)) {
         mHeap.push(Ranking(thing, score));
-        if(mHeap.size() > mMaxCount) {
+        Size size = mHeap.size();
+
+        if(size > mMaxCount) {
           mHeap.pop();
+        }
+
+        if(size >= mMaxCount) {
           mTopScore = mHeap.top().score();
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 FLAGS = -std=c++11 -O3 -Wall -Werror
-LIBS  = -lrt
+# LIBS  = -lrt
 
 all: example.out benchmark.out
 example.out: test/example.cpp Chaff.h

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -32,10 +32,10 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
-  const int DATA = std::stoi(argv[1]);
-  const int FIND = std::stoi(argv[2]);
-  const int REPS = std::stoi(argv[3]);
-  const int SEED = (argc == 5)? std::stoi(argv[4]): time(nullptr);
+  const int DATA = std::atoi(argv[1]);
+  const int FIND = std::atoi(argv[2]);
+  const int REPS = std::atoi(argv[3]);
+  const int SEED = (argc == 5)? std::atoi(argv[4]): time(nullptr);
   printf("%s %i %i %i %i\n", argv[0], DATA, FIND, REPS, SEED);
 
   srand(SEED);
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
     std::vector<int> cmax_data;
     std::vector<int> smin_data;
     std::vector<int> smax_data;
-    
+
     cmin_time += bench([&]() {
       auto q = Chaff::MinFinder<int, int>::byCount(FIND);
       for(int i = 0; i < DATA; ++i) q.sow(data[i], data[i]);


### PR DESCRIPTION
Not exactly a bug, but the original version wouldn't update `mTopScore` until something had been popped off of the heap. This version updates it as soon as the heap gets full.  Should lead to more consistent behavior.

Also fixed a couple compile errors as seen on my Mac.  Hopefully the changes don't break CI...